### PR TITLE
Enable extensions to link against us

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -15,3 +15,9 @@ If:
     PathMatch: src/.*\.in
 Diagnostics:
     Suppress: expected_expression
+---
+# Make sure the highlighting acts as if we're exporting
+If:
+    PathMatch: src/.*
+CompileFlags:
+    Add: [-DPYUNREALSDK_INTERNAL]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,17 +21,18 @@ set(GIT_PRE_CONFIGURE_FILE "src/pyunrealsdk/version.cpp.in")
 set(GIT_POST_CONFIGURE_FILE "${CMAKE_CURRENT_BINARY_DIR}/version.cpp")
 include(common_cmake/git_watcher.cmake)
 
-add_subdirectory(common_cmake/explicit_python)
-
 set(PYBIND11_NOPYTHON True)
 add_subdirectory(libs/pybind11 EXCLUDE_FROM_ALL)
 
 set(UNREALSDK_SHARED True)
 add_subdirectory(libs/unrealsdk EXCLUDE_FROM_ALL)
 
+# Make sure to include after unrealsdk, to make sure the arch define is set
+add_subdirectory(common_cmake/explicit_python)
+
 file(GLOB_RECURSE sources CONFIGURE_DEPENDS "src/pyunrealsdk/*.cpp" "src/pyunrealsdk/*.h")
 list(APPEND sources ${GIT_POST_CONFIGURE_FILE})
-target_sources(pyunrealsdk PRIVATE ${sources})
+target_sources(pyunrealsdk PUBLIC ${sources})
 
 target_include_directories(pyunrealsdk PUBLIC "src")
 target_link_libraries(pyunrealsdk PUBLIC
@@ -50,6 +51,7 @@ target_compile_definitions(pyunrealsdk PUBLIC
     PYBIND11_SIMPLE_GIL_MANAGEMENT
     PYBIND11_DETAILED_ERROR_MESSAGES
 )
+target_compile_definitions(pyunrealsdk PRIVATE PYUNREALSDK_INTERNAL)
 
 target_precompile_headers(pyunrealsdk PUBLIC "src/pyunrealsdk/pch.h")
 

--- a/src/pyunrealsdk/base_bindings.cpp
+++ b/src/pyunrealsdk/base_bindings.cpp
@@ -14,6 +14,8 @@
 #include "unrealsdk/unrealsdk.h"
 #include "unrealsdk/utils.h"
 
+#ifdef PYUNREALSDK_INTERNAL
+
 namespace pyunrealsdk {
 
 using namespace unrealsdk::unreal;
@@ -220,3 +222,5 @@ void register_base_bindings(py::module_& mod) {
 }
 
 }  // namespace pyunrealsdk
+
+#endif

--- a/src/pyunrealsdk/base_bindings.h
+++ b/src/pyunrealsdk/base_bindings.h
@@ -3,6 +3,8 @@
 
 #include "pyunrealsdk/pch.h"
 
+#ifdef PYUNREALSDK_INTERNAL
+
 namespace pyunrealsdk {
 
 /**
@@ -13,5 +15,7 @@ namespace pyunrealsdk {
 void register_base_bindings(py::module_& mod);
 
 }  // namespace pyunrealsdk
+
+#endif
 
 #endif /* PYUNREALSDK_BASE_BINDINGS_H */

--- a/src/pyunrealsdk/commands.cpp
+++ b/src/pyunrealsdk/commands.cpp
@@ -4,6 +4,8 @@
 #include "unrealsdk/commands.h"
 #include "unrealsdk/utils.h"
 
+#ifdef PYUNREALSDK_INTERNAL
+
 namespace pyunrealsdk::commands {
 
 namespace {
@@ -172,3 +174,5 @@ void register_commands(void) {
 }
 
 }  // namespace pyunrealsdk::commands
+
+#endif

--- a/src/pyunrealsdk/commands.h
+++ b/src/pyunrealsdk/commands.h
@@ -3,6 +3,8 @@
 
 #include "pyunrealsdk/pch.h"
 
+#ifdef PYUNREALSDK_INTERNAL
+
 namespace pyunrealsdk::commands {
 
 /**
@@ -18,5 +20,7 @@ void register_module(py::module_& mod);
 void register_commands(void);
 
 }  // namespace pyunrealsdk::commands
+
+#endif
 
 #endif /* PYUNREALSDK_COMMANDS_H */

--- a/src/pyunrealsdk/dllmain.cpp
+++ b/src/pyunrealsdk/dllmain.cpp
@@ -1,6 +1,8 @@
 #include "pyunrealsdk/pch.h"
 #include "pyunrealsdk/pyunrealsdk.h"
 
+#ifdef PYUNREALSDK_INTERNAL
+
 namespace {
 
 /**
@@ -42,3 +44,5 @@ BOOL APIENTRY DllMain(HMODULE h_module, DWORD ul_reason_for_call, LPVOID /*unuse
     }
     return TRUE;
 }
+
+#endif

--- a/src/pyunrealsdk/exports.h
+++ b/src/pyunrealsdk/exports.h
@@ -1,0 +1,66 @@
+#ifndef PYUNREALSDK_EXPORTS_H
+#define PYUNREALSDK_EXPORTS_H
+
+/*
+Helper macros to deal with exported functions.
+
+User code should never need to use these, they should always be hidden in implementation files.
+*/
+
+/**
+ * @fn PYUNREALSDK_MANGLE
+ * @brief Mangles an exported symbol name.
+ *
+ * @param name The name to mangle.
+ * @return The mangled name
+ */
+
+/**
+ * @fn PYUNREALSDK_CAPI
+ * @brief Declares an exported C function.
+ * @note The exported function is automatically mangled, use `UNREALSDK_MANGLE()` when calling it.
+ *
+ * @param ret The return type. May include attributes.
+ * @param name The function name.
+ * @param ... The function args (including types).
+ * @returns A function declaration. May be left as a forward declaration, or used in the definition.
+ */
+
+// =================================================================================================
+
+// Unconditionally mangle - if we disabled this when not shared we might cause name conflicts (e.g.
+// if only the return type differs)
+#define PYUNREALSDK_MANGLE(name) _pyunrealsdk_export__##name
+
+// Determine the correct dllimport/export attribute
+#if defined(PYUNREALSDK_INTERNAL)
+
+#if defined(__clang__) || defined(__MINGW32__)
+#define PYUNREALSDK_DLLEXPORT [[gnu::dllexport]]
+#elif defined(_MSC_VER)
+#define PYUNREALSDK_DLLEXPORT __declspec(dllexport)
+#else
+#error Unknown dllexport attribute
+#endif
+
+#else  //  defined(PYUNREALSDK_INTERNAL)
+
+#if defined(__clang__) || defined(__MINGW32__)
+#define PYUNREALSDK_DLLEXPORT [[gnu::dllimport]]
+#elif defined(_MSC_VER)
+#define PYUNREALSDK_DLLEXPORT __declspec(dllimport)
+#else
+#error Unknown dllimport attribute
+#endif
+
+#endif  //  defined(PYUNREALSDK_INTERNAL)
+
+// Need extern C to create a valid export
+// Use the relevant dllimport/export attribute
+// Mangle the function name to avoid conflicts
+// MSVC needs noexpect(false) to allow exceptions through the C interface - since it's standard C++,
+//  might as well just add across all compilers
+#define PYUNREALSDK_CAPI(ret, name, ...) \
+    extern "C" PYUNREALSDK_DLLEXPORT ret PYUNREALSDK_MANGLE(name)(__VA_ARGS__) noexcept(false)
+
+#endif /* PYUNREALSDK_EXPORTS_H */

--- a/src/pyunrealsdk/hook.cpp
+++ b/src/pyunrealsdk/hook.cpp
@@ -6,6 +6,8 @@
 #include "unrealsdk/unreal/prop_traits.h"
 #include "unrealsdk/unreal/wrappers/property_proxy.h"
 
+#ifdef PYUNREALSDK_INTERNAL
+
 using namespace unrealsdk::unreal;
 using namespace unrealsdk::hook_manager;
 
@@ -189,3 +191,5 @@ void register_module(py::module_& mod) {
 }
 
 }  // namespace pyunrealsdk::hooks
+
+#endif

--- a/src/pyunrealsdk/hooks.h
+++ b/src/pyunrealsdk/hooks.h
@@ -3,19 +3,25 @@
 
 #include "pyunrealsdk/pch.h"
 
-#ifdef PYUNREALSDK_INTERNAL
-
 namespace pyunrealsdk::hooks {
 
+#ifdef PYUNREALSDK_INTERNAL
 /**
  * @brief Registers everything needed for the hooks module.
  *
  * @param mod The module to register within.
  */
 void register_module(py::module_& mod);
+#endif
+
+/**
+ * @brief Checks if a python object is the block sentinel.
+ *
+ * @param obj The object to check.
+ * @return True if the object says to block execution.
+ */
+bool is_block_sentinel(const py::object& obj);
 
 }  // namespace pyunrealsdk::hooks
-
-#endif
 
 #endif /* PYUNREALSDK_HOOKS_H */

--- a/src/pyunrealsdk/hooks.h
+++ b/src/pyunrealsdk/hooks.h
@@ -3,6 +3,8 @@
 
 #include "pyunrealsdk/pch.h"
 
+#ifdef PYUNREALSDK_INTERNAL
+
 namespace pyunrealsdk::hooks {
 
 /**
@@ -13,5 +15,7 @@ namespace pyunrealsdk::hooks {
 void register_module(py::module_& mod);
 
 }  // namespace pyunrealsdk::hooks
+
+#endif
 
 #endif /* PYUNREALSDK_HOOKS_H */

--- a/src/pyunrealsdk/logging.cpp
+++ b/src/pyunrealsdk/logging.cpp
@@ -40,6 +40,8 @@ std::pair<std::string, int> get_python_location(PyFrameObject* frame = nullptr) 
     return {filename, line_num};
 }
 
+#ifdef PYUNREALSDK_INTERNAL
+
 /**
  * @brief A write only file object which redirects to the unrealsdk log system.
  */
@@ -133,7 +135,11 @@ void register_per_log_level_printer(py::module_& logging,
         docstring.c_str());
 }
 
+#endif
+
 }  // namespace
+
+#ifdef PYUNREALSDK_INTERNAL
 
 void register_module(py::module_& mod) {
     auto logging = mod.def_submodule("logging");
@@ -202,6 +208,8 @@ void py_init(void) {
     sys.attr("stdout") = Logger{Level::INFO};
     sys.attr("stderr") = Logger{Level::ERROR};
 }
+
+#endif
 
 void log_python_exception(const std::exception& exc) {
     PyFrameObject* frame = nullptr;

--- a/src/pyunrealsdk/logging.h
+++ b/src/pyunrealsdk/logging.h
@@ -5,6 +5,8 @@
 
 namespace pyunrealsdk::logging {
 
+#ifdef PYUNREALSDK_INTERNAL
+
 /**
  * @brief Registers everything needed for the logging module.
  *
@@ -17,6 +19,8 @@ void register_module(py::module_& mod);
  * @note Sets up the stdout/err redirection.
  */
 void py_init(void);
+
+#endif
 
 /**
  * @brief Logs an exception using the current python stack frame.

--- a/src/pyunrealsdk/pch.h
+++ b/src/pyunrealsdk/pch.h
@@ -1,36 +1,11 @@
 #ifndef PYUNREALSDK_PCH_H
 #define PYUNREALSDK_PCH_H
 
-#if defined(PYUNREALSDK_INTERNAL)
+// Include the C exports library first, so we can use it everywhere
+// This file is purely macros, it doesn't rely on anything else
+#include "pyunrealsdk/exports.h"
 
-// If compiling internals, C api functions are exported
-#if defined(__clang__) || defined(__MINGW32__)
-#define PYUNREALSDK_CAPI extern "C" [[gnu::dllexport]]
-#elif defined(_MSC_VER)
-#define PYUNREALSDK_CAPI extern "C" __declspec(dllexport)
-#else
-#error Unknown dllexport attribute
-#endif
-
-// MSVC needs this to allow exceptions through the C interface
-// Since it's standard C++, might as well just add it to everything
-#define PYUNREALSDK_CAPI_SUFFIX noexcept(false)
-
-#else
-
-// If included as a library, we want to import from the internals
-#if defined(__clang__) || defined(__MINGW32__)
-#define PYUNREALSDK_CAPI extern "C" [[gnu::dllimport]]
-#elif defined(_MSC_VER)
-#define PYUNREALSDK_CAPI extern "C" __declspec(dllimport)
-#else
-#error Unknown dllimport attribute
-#endif
-
-#define PYUNREALSDK_CAPI_SUFFIX noexcept(false)
-
-#endif
-
+// Inherit all of unrealsdk's PCH
 #include "unrealsdk/pch.h"
 
 #ifdef __clang__

--- a/src/pyunrealsdk/pch.h
+++ b/src/pyunrealsdk/pch.h
@@ -1,6 +1,36 @@
 #ifndef PYUNREALSDK_PCH_H
 #define PYUNREALSDK_PCH_H
 
+#if defined(PYUNREALSDK_INTERNAL)
+
+// If compiling internals, C api functions are exported
+#if defined(__clang__) || defined(__MINGW32__)
+#define PYUNREALSDK_CAPI extern "C" [[gnu::dllexport]]
+#elif defined(_MSC_VER)
+#define PYUNREALSDK_CAPI extern "C" __declspec(dllexport)
+#else
+#error Unknown dllexport attribute
+#endif
+
+// MSVC needs this to allow exceptions through the C interface
+// Since it's standard C++, might as well just add it to everything
+#define PYUNREALSDK_CAPI_SUFFIX noexcept(false)
+
+#else
+
+// If included as a library, we want to import from the internals
+#if defined(__clang__) || defined(__MINGW32__)
+#define PYUNREALSDK_CAPI extern "C" [[gnu::dllimport]]
+#elif defined(_MSC_VER)
+#define PYUNREALSDK_CAPI extern "C" __declspec(dllimport)
+#else
+#error Unknown dllimport attribute
+#endif
+
+#define PYUNREALSDK_CAPI_SUFFIX noexcept(false)
+
+#endif
+
 #include "unrealsdk/pch.h"
 
 #ifdef __clang__

--- a/src/pyunrealsdk/pyunrealsdk.cpp
+++ b/src/pyunrealsdk/pyunrealsdk.cpp
@@ -9,6 +9,8 @@
 #include "unrealsdk/unrealsdk.h"
 #include "unrealsdk/version.h"
 
+#ifdef PYUNREALSDK_INTERNAL
+
 // NOLINTNEXTLINE(readability-identifier-length)
 PYBIND11_EMBEDDED_MODULE(unrealsdk, m) {
     m.attr("__version__") = unrealsdk::get_version_string();
@@ -80,3 +82,5 @@ void init(void) {
 }
 
 }  // namespace pyunrealsdk
+
+#endif

--- a/src/pyunrealsdk/pyunrealsdk.h
+++ b/src/pyunrealsdk/pyunrealsdk.h
@@ -1,6 +1,8 @@
 #ifndef PYUNREALSDK_PYUNREALSDK_H
 #define PYUNREALSDK_PYUNREALSDK_H
 
+#ifdef PYUNREALSDK_INTERNAL
+
 namespace pyunrealsdk {
 
 /**
@@ -9,5 +11,7 @@ namespace pyunrealsdk {
 void init(void);
 
 }  // namespace pyunrealsdk
+
+#endif
 
 #endif /* PYUNREALSDK_PYUNREALSDK_H */

--- a/src/pyunrealsdk/type_casters.cpp
+++ b/src/pyunrealsdk/type_casters.cpp
@@ -3,6 +3,8 @@
 #include "unrealsdk/unreal/cast.h"
 #include "unrealsdk/unreal/classes/uobject.h"
 
+#ifdef PYUNREALSDK_INTERNAL
+
 using namespace unrealsdk::unreal;
 
 namespace pyunrealsdk::type_casters {
@@ -21,3 +23,5 @@ const void* downcast_unreal(const UObject* src, const std::type_info*& type) {
 }
 
 }  // namespace pyunrealsdk::type_casters
+
+#endif

--- a/src/pyunrealsdk/type_casters.h
+++ b/src/pyunrealsdk/type_casters.h
@@ -13,6 +13,10 @@ class UObject;
 
 }
 
+#ifdef PYUNREALSDK_INTERNAL
+// TODO: Provide a downcaster for external modules
+//       We can't use this one because std::type_info isn't safe to cross between dlls
+
 namespace pyunrealsdk::type_casters {
 
 /**
@@ -26,8 +30,11 @@ const void* downcast_unreal(const unrealsdk::unreal::UObject* src, const std::ty
 
 }  // namespace pyunrealsdk::type_casters
 
+#endif
+
 namespace pybind11 {
 
+#ifdef PYUNREALSDK_INTERNAL
 // Make the UObject hierarchy automatically downcast
 template <typename itype>
 struct polymorphic_type_hook<
@@ -37,6 +44,7 @@ struct polymorphic_type_hook<
         return pyunrealsdk::type_casters::downcast_unreal(src, type);
     }
 };
+#endif
 
 namespace detail {
 

--- a/src/pyunrealsdk/unreal_bindings/bindings.cpp
+++ b/src/pyunrealsdk/unreal_bindings/bindings.cpp
@@ -11,6 +11,8 @@
 #include "unrealsdk/unreal/classes/ustruct.h"
 #include "unrealsdk/unreal/classes/ustruct_funcs.h"
 
+#ifdef PYUNREALSDK_INTERNAL
+
 using namespace unrealsdk::unreal;
 
 namespace pyunrealsdk::unreal {
@@ -29,3 +31,5 @@ void register_module(py::module_& mod) {
 }
 
 }  // namespace pyunrealsdk::unreal
+
+#endif

--- a/src/pyunrealsdk/unreal_bindings/bindings.h
+++ b/src/pyunrealsdk/unreal_bindings/bindings.h
@@ -5,6 +5,8 @@
 #include "unrealsdk/unreal/classes/ufield.h"
 #include "unrealsdk/unreal/classes/ustruct.h"
 
+#ifdef PYUNREALSDK_INTERNAL
+
 namespace pyunrealsdk::unreal {
 
 /**
@@ -24,5 +26,7 @@ template <typename T, typename... Options>
 using PyUEClass = py::class_<T, Options..., std::unique_ptr<T, py::nodelete>>;
 
 }  // namespace pyunrealsdk::unreal
+
+#endif
 
 #endif /* PYUNREALSDK_UNREAL_BINDINGS_UNREAL_H */

--- a/src/pyunrealsdk/unreal_bindings/bound_function.cpp
+++ b/src/pyunrealsdk/unreal_bindings/bound_function.cpp
@@ -10,6 +10,8 @@
 #include "unrealsdk/unreal/wrappers/bound_function.h"
 #include "unrealsdk/unreal/wrappers/wrapped_struct.h"
 
+#ifdef PYUNREALSDK_INTERNAL
+
 using namespace unrealsdk::unreal;
 
 namespace pyunrealsdk::unreal {
@@ -208,4 +210,7 @@ void register_bound_function(py::module_& mod) {
         .def_readwrite("func", &BoundFunction::func)
         .def_readwrite("object", &BoundFunction::object);
 }
+
 }  // namespace pyunrealsdk::unreal
+
+#endif

--- a/src/pyunrealsdk/unreal_bindings/bound_function.h
+++ b/src/pyunrealsdk/unreal_bindings/bound_function.h
@@ -3,6 +3,8 @@
 
 #include "pyunrealsdk/pch.h"
 
+#ifdef PYUNREALSDK_INTERNAL
+
 namespace pyunrealsdk::unreal {
 
 /**
@@ -13,5 +15,7 @@ namespace pyunrealsdk::unreal {
 void register_bound_function(py::module_& mod);
 
 }  // namespace pyunrealsdk::unreal
+
+#endif
 
 #endif /* PYUNREALSDK_UNREAL_BINDINGS_BOUND_FUNCTION_H */

--- a/src/pyunrealsdk/unreal_bindings/property_access.cpp
+++ b/src/pyunrealsdk/unreal_bindings/property_access.cpp
@@ -19,6 +19,8 @@
 #include "unrealsdk/unreal/wrappers/bound_function.h"
 #include "unrealsdk/unreal/wrappers/wrapped_array.h"
 
+#ifdef PYUNREALSDK_INTERNAL
+
 using namespace unrealsdk::unreal;
 
 namespace pyunrealsdk::unreal {
@@ -192,3 +194,5 @@ void py_setattr(UField* field, uintptr_t base_addr, const py::object& value) {
 }
 
 }  // namespace pyunrealsdk::unreal
+
+#endif

--- a/src/pyunrealsdk/unreal_bindings/property_access.h
+++ b/src/pyunrealsdk/unreal_bindings/property_access.h
@@ -4,6 +4,8 @@
 #include "pyunrealsdk/pch.h"
 #include "unrealsdk/unreal/wrappers/unreal_pointer.h"
 
+#ifdef PYUNREALSDK_INTERNAL
+
 namespace unrealsdk::unreal {
 
 struct FName;
@@ -66,5 +68,7 @@ py::object py_getattr(unrealsdk::unreal::UField* field,
 void py_setattr(unrealsdk::unreal::UField* field, uintptr_t base_addr, const py::object& value);
 
 }  // namespace pyunrealsdk::unreal
+
+#endif
 
 #endif /* PYUNREALSDK_UNREAL_BINDINGS_PROPERTY_ACCESS_H */

--- a/src/pyunrealsdk/unreal_bindings/uenum.cpp
+++ b/src/pyunrealsdk/unreal_bindings/uenum.cpp
@@ -8,7 +8,7 @@ using namespace unrealsdk::unreal;
 
 namespace pyunrealsdk::unreal {
 
-PYUNREALSDK_CAPI PyObject* enum_as_py_enum_capi(const UEnum* enum_obj) PYUNREALSDK_CAPI_SUFFIX;
+PYUNREALSDK_CAPI(PyObject*, enum_as_py_enum, const UEnum* enum_obj);
 
 #ifdef PYUNREALSDK_INTERNAL
 
@@ -36,7 +36,7 @@ py::object enum_as_py_enum(const UEnum* enum_obj) {
     return enum_cache[enum_obj];
 }
 
-PYUNREALSDK_CAPI PyObject* enum_as_py_enum_capi(const UEnum* enum_obj) PYUNREALSDK_CAPI_SUFFIX {
+PYUNREALSDK_CAPI(PyObject*, enum_as_py_enum, const UEnum* enum_obj) {
     const py::gil_scoped_acquire gil{};
 
     auto obj = enum_as_py_enum(enum_obj);
@@ -49,7 +49,7 @@ py::object enum_as_py_enum(const UEnum* enum_obj) {
     const py::gil_scoped_acquire gil{};
 
     // Steal the reference which we incremented on the other side of this call
-    return py::reinterpret_steal<py::object>(enum_as_py_enum_capi(enum_obj));
+    return py::reinterpret_steal<py::object>(PYUNREALSDK_MANGLE(enum_as_py_enum)(enum_obj));
 }
 #endif
 

--- a/src/pyunrealsdk/unreal_bindings/uenum.h
+++ b/src/pyunrealsdk/unreal_bindings/uenum.h
@@ -11,12 +11,16 @@ class UEnum;
 
 namespace pyunrealsdk::unreal {
 
+#ifdef PYUNREALSDK_INTERNAL
+
 /**
  * @brief Registers UEnum.
  *
  * @param mod The module to register within.
  */
 void register_uenum(py::module_& mod);
+
+#endif
 
 /**
  * @brief Creates a python enum from an unreal enum.

--- a/src/pyunrealsdk/unreal_bindings/uobject.cpp
+++ b/src/pyunrealsdk/unreal_bindings/uobject.cpp
@@ -9,6 +9,8 @@
 #include "unrealsdk/unrealsdk.h"
 #include "unrealsdk/utils.h"
 
+#ifdef PYUNREALSDK_INTERNAL
+
 using namespace unrealsdk::unreal;
 
 namespace pyunrealsdk::unreal {
@@ -133,3 +135,5 @@ void register_uobject(py::module_& mod) {
 }
 
 }  // namespace pyunrealsdk::unreal
+
+#endif

--- a/src/pyunrealsdk/unreal_bindings/uobject.h
+++ b/src/pyunrealsdk/unreal_bindings/uobject.h
@@ -3,6 +3,8 @@
 
 #include "pyunrealsdk/pch.h"
 
+#ifdef PYUNREALSDK_INTERNAL
+
 namespace pyunrealsdk::unreal {
 
 /**
@@ -13,5 +15,7 @@ namespace pyunrealsdk::unreal {
 void register_uobject(py::module_& mod);
 
 }  // namespace pyunrealsdk::unreal
+
+#endif
 
 #endif /* PYUNREALSDK_UNREAL_BINDINGS_UOBJECT_H */

--- a/src/pyunrealsdk/unreal_bindings/uobject_children.cpp
+++ b/src/pyunrealsdk/unreal_bindings/uobject_children.cpp
@@ -23,6 +23,8 @@
 #include "unrealsdk/unreal/classes/ustruct.h"
 #include "unrealsdk/unreal/wrappers/wrapped_struct.h"
 
+#ifdef PYUNREALSDK_INTERNAL
+
 using namespace unrealsdk::unreal;
 
 namespace pyunrealsdk::unreal {
@@ -204,3 +206,5 @@ void register_uobject_children(py::module_& mod) {
 }
 
 }  // namespace pyunrealsdk::unreal
+
+#endif

--- a/src/pyunrealsdk/unreal_bindings/uobject_children.h
+++ b/src/pyunrealsdk/unreal_bindings/uobject_children.h
@@ -3,6 +3,8 @@
 
 #include "pyunrealsdk/pch.h"
 
+#ifdef PYUNREALSDK_INTERNAL
+
 namespace pyunrealsdk::unreal {
 
 /**
@@ -13,5 +15,7 @@ namespace pyunrealsdk::unreal {
 void register_uobject_children(py::module_& mod);
 
 }  // namespace pyunrealsdk::unreal
+
+#endif
 
 #endif /* PYUNREALSDK_UNREAL_BINDINGS_UCLASS_H */

--- a/src/pyunrealsdk/unreal_bindings/wrapped_array.cpp
+++ b/src/pyunrealsdk/unreal_bindings/wrapped_array.cpp
@@ -2,6 +2,8 @@
 #include "pyunrealsdk/unreal_bindings/wrapped_array.h"
 #include "unrealsdk/unreal/wrappers/wrapped_array.h"
 
+#ifdef PYUNREALSDK_INTERNAL
+
 using namespace unrealsdk::unreal;
 
 namespace pyunrealsdk::unreal {
@@ -201,4 +203,7 @@ void register_wrapped_array(py::module_& mod) {
                          "cls"_a)
             .ptr()));
 }
+
 }  // namespace pyunrealsdk::unreal
+
+#endif

--- a/src/pyunrealsdk/unreal_bindings/wrapped_array.h
+++ b/src/pyunrealsdk/unreal_bindings/wrapped_array.h
@@ -3,6 +3,8 @@
 
 #include "pyunrealsdk/pch.h"
 
+#ifdef PYUNREALSDK_INTERNAL
+
 namespace unrealsdk::unreal {
 
 class WrappedArray;
@@ -207,5 +209,7 @@ void array_py_sort(WrappedArray& self, const py::object& key, bool reverse);
 }  // namespace impl
 
 }  // namespace pyunrealsdk::unreal
+
+#endif
 
 #endif /* PYUNREALSDK_UNREAL_BINDINGS_WRAPPED_ARRAY_H */

--- a/src/pyunrealsdk/unreal_bindings/wrapped_array_helpers.cpp
+++ b/src/pyunrealsdk/unreal_bindings/wrapped_array_helpers.cpp
@@ -3,6 +3,8 @@
 #include "unrealsdk/unreal/cast.h"
 #include "unrealsdk/unreal/wrappers/wrapped_array.h"
 
+#ifdef PYUNREALSDK_INTERNAL
+
 using namespace unrealsdk::unreal;
 
 namespace pyunrealsdk::unreal::impl {
@@ -107,3 +109,5 @@ ArrayIterator ArrayIterator::end(const WrappedArray& arr) {
 }
 
 }  // namespace pyunrealsdk::unreal::impl
+
+#endif

--- a/src/pyunrealsdk/unreal_bindings/wrapped_array_magic_methods.cpp
+++ b/src/pyunrealsdk/unreal_bindings/wrapped_array_magic_methods.cpp
@@ -3,6 +3,8 @@
 #include "unrealsdk/unreal/cast.h"
 #include "unrealsdk/unreal/wrappers/wrapped_array.h"
 
+#ifdef PYUNREALSDK_INTERNAL
+
 using namespace unrealsdk::unreal;
 
 namespace pyunrealsdk::unreal::impl {
@@ -233,3 +235,5 @@ py::type array_py_class_getitem(const py::type& cls,
 }
 
 }  // namespace pyunrealsdk::unreal::impl
+
+#endif

--- a/src/pyunrealsdk/unreal_bindings/wrapped_array_methods.cpp
+++ b/src/pyunrealsdk/unreal_bindings/wrapped_array_methods.cpp
@@ -3,6 +3,8 @@
 #include "unrealsdk/unreal/cast.h"
 #include "unrealsdk/unreal/wrappers/wrapped_array.h"
 
+#ifdef PYUNREALSDK_INTERNAL
+
 using namespace unrealsdk::unreal;
 
 namespace pyunrealsdk::unreal::impl {
@@ -152,3 +154,5 @@ void array_py_sort(WrappedArray& self, const py::object& key, bool reverse) {
 }
 
 }  // namespace pyunrealsdk::unreal::impl
+
+#endif

--- a/src/pyunrealsdk/unreal_bindings/wrapped_struct.cpp
+++ b/src/pyunrealsdk/unreal_bindings/wrapped_struct.cpp
@@ -6,6 +6,8 @@
 #include "unrealsdk/unreal/wrappers/unreal_pointer.h"
 #include "unrealsdk/unreal/wrappers/wrapped_struct.h"
 
+#ifdef PYUNREALSDK_INTERNAL
+
 using namespace unrealsdk::unreal;
 
 namespace pyunrealsdk::unreal {
@@ -168,3 +170,5 @@ void register_wrapped_struct(py::module_& mod) {
 }
 
 }  // namespace pyunrealsdk::unreal
+
+#endif

--- a/src/pyunrealsdk/unreal_bindings/wrapped_struct.h
+++ b/src/pyunrealsdk/unreal_bindings/wrapped_struct.h
@@ -3,6 +3,8 @@
 
 #include "pyunrealsdk/pch.h"
 
+#ifdef PYUNREALSDK_INTERNAL
+
 namespace unrealsdk::unreal {
 
 class UScriptStruct;
@@ -32,5 +34,7 @@ unrealsdk::unreal::WrappedStruct make_struct(const unrealsdk::unreal::UScriptStr
                                              const py::kwargs& kwargs);
 
 }  // namespace pyunrealsdk::unreal
+
+#endif
 
 #endif /* PYUNREALSDK_UNREAL_BINDINGS_WRAPPED_STRUCT_H */

--- a/src/pyunrealsdk/version.cpp.in
+++ b/src/pyunrealsdk/version.cpp.in
@@ -1,6 +1,8 @@
 #include "pyunrealsdk/pch.h"
 #include "pyunrealsdk/version.h"
 
+#ifdef PYUNREALSDK_INTERNAL
+
 namespace pyunrealsdk {
 
 namespace {
@@ -29,3 +31,5 @@ const std::string& get_version_string(void) {
 }
 
 }  // namespace pyunrealsdk
+
+#endif

--- a/src/pyunrealsdk/version.cpp.in
+++ b/src/pyunrealsdk/version.cpp.in
@@ -1,8 +1,6 @@
 #include "pyunrealsdk/pch.h"
 #include "pyunrealsdk/version.h"
 
-#ifdef PYUNREALSDK_INTERNAL
-
 namespace pyunrealsdk {
 
 namespace {
@@ -16,6 +14,21 @@ namespace {
 [[maybe_unused]] const constexpr bool GIT_DIRTY = @GIT_IS_DIRTY@;
 // clang-format on
 
+}  // namespace
+
+PYUNREALSDK_CAPI([[nodiscard]] uint32_t, get_version);
+#ifdef PYUNREALSDK_INTERNAL
+PYUNREALSDK_CAPI([[nodiscard]] uint32_t, get_version) {
+    // NOLINTNEXTLINE(readability-magic-numbers)
+    return (VERSION_MAJOR & 0xFF) << 16 | (VERSION_MINOR & 0xFF) << 8 | (VERSION_PATCH & 0xFF);
+}
+#endif
+[[nodiscard]] uint32_t get_version(void) {
+    return PYUNREALSDK_MANGLE(get_version)();
+}
+
+namespace {
+#ifdef PYUNREALSDK_INTERNAL
 const constexpr auto GIT_HASH_CHARS = 8;
 const std::string VERSION_STR = unrealsdk::fmt::format("pyunrealsdk v{}.{}.{} ({}{})",
                                                        VERSION_MAJOR,
@@ -23,13 +36,24 @@ const std::string VERSION_STR = unrealsdk::fmt::format("pyunrealsdk v{}.{}.{} ({
                                                        VERSION_PATCH,
                                                        GIT_HASH.substr(0, GIT_HASH_CHARS),
                                                        GIT_DIRTY ? ", dirty" : "");
-
+#endif
 }  // namespace
 
-const std::string& get_version_string(void) {
-    return VERSION_STR;
+PYUNREALSDK_CAPI([[nodiscard]] const char*, get_version_string);
+#ifdef PYUNREALSDK_INTERNAL
+PYUNREALSDK_CAPI([[nodiscard]] const char*, get_version_string) {
+    return VERSION_STR.data();
 }
 
-}  // namespace pyunrealsdk
-
+[[nodiscard]] const std::string& get_version_string(void) {
+    return VERSION_STR;
+}
+#else
+[[nodiscard]] const std::string& get_version_string(void) {
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    static const std::string VERSION_STR = PYUNREALSDK_MANGLE(get_version_string)();
+    return VERSION_STR;
+}
 #endif
+
+}  // namespace pyunrealsdk

--- a/src/pyunrealsdk/version.h
+++ b/src/pyunrealsdk/version.h
@@ -3,23 +3,31 @@
 
 #include "pyunrealsdk/pch.h"
 
-#ifdef PYUNREALSDK_INTERNAL
-
 namespace pyunrealsdk {
+
+#ifdef PYUNREALSDK_INTERNAL
 
 inline constexpr auto VERSION_MAJOR = 1;
 inline constexpr auto VERSION_MINOR = 0;
 inline constexpr auto VERSION_PATCH = 0;
 
+#endif
+
+/**
+ * @brief Gets the version number of the python sdk.
+ * @note Packs as `(major & 0xFF) << 16 | (minor & 0xFF) << 8 | (patch & 0xFF)`.
+ *
+ * @return The packed version number the python sdk was compiled with.
+ */
+[[nodiscard]] uint32_t get_version(void);
+
 /**
  * @brief Get the python sdk version as a printable string.
  *
- * @return The sdk version string.
+ * @return The python sdk version string.
  */
-const std::string& get_version_string(void);
+[[nodiscard]] const std::string& get_version_string(void);
 
 }  // namespace pyunrealsdk
-
-#endif
 
 #endif /* PYUNREALSDK_VERSION_H */

--- a/src/pyunrealsdk/version.h
+++ b/src/pyunrealsdk/version.h
@@ -3,6 +3,8 @@
 
 #include "pyunrealsdk/pch.h"
 
+#ifdef PYUNREALSDK_INTERNAL
+
 namespace pyunrealsdk {
 
 inline constexpr auto VERSION_MAJOR = 1;
@@ -17,5 +19,7 @@ inline constexpr auto VERSION_PATCH = 0;
 const std::string& get_version_string(void);
 
 }  // namespace pyunrealsdk
+
+#endif
 
 #endif /* PYUNREALSDK_VERSION_H */


### PR DESCRIPTION
Very limited interface for now, will expose more as it's needed:
- FName caster (statically linked)
- Exception logging helper (statically linked)
- Version number/string
- Python enum lookup
- Block sentinel check