### PR TITLE
better enum type hinting

### DIFF
--- a/stubs/unrealsdk/__init__.pyi
+++ b/stubs/unrealsdk/__init__.pyi
@@ -5,7 +5,7 @@ from typing import Any
 
 from . import commands, hooks, logging, unreal
 from .unreal import UClass, UObject, WrappedStruct
-from .unreal._uenum import _UnrealEnum  # pyright: ignore[reportPrivateUsage]
+from .unreal._uenum import _GenericUnrealEnum  # pyright: ignore[reportPrivateUsage]
 
 __all__: tuple[str, ...] = (
     "__version__",
@@ -73,7 +73,7 @@ def find_class(name: str, fully_qualified: None | bool = None) -> UClass:
         The class, or None if not found.
     """
 
-def find_enum(name: str, fully_qualified: None | bool = None) -> type[_UnrealEnum]:
+def find_enum(name: str, fully_qualified: None | bool = None) -> type[_GenericUnrealEnum]:
     """
     Finds an enum by name.
 

--- a/stubs/unrealsdk/unreal/_uenum.pyi
+++ b/stubs/unrealsdk/unreal/_uenum.pyi
@@ -5,13 +5,41 @@ from enum import EnumMeta, IntFlag
 from ._uobject_children import UField
 
 class _UnrealEnumMeta(EnumMeta):
-    def __getattr__(self, name: str) -> IntFlag: ...
-
-class _UnrealEnum(IntFlag, metaclass=_UnrealEnumMeta):
     _unreal: UEnum
 
+class _GenericUnrealEnumMeta(_UnrealEnumMeta):
+    def __getattr__(self, name: str) -> IntFlag: ...
+
+class _GenericUnrealEnum(IntFlag, metaclass=_GenericUnrealEnumMeta): ...
+
+class UnrealEnum(IntFlag, metaclass=_UnrealEnumMeta):
+    """
+    Base unreal enum class which can be used to type hint specific instances.
+
+    Note this class *DOES NOT* exist at runtime.
+
+    Suggested usage:
+    ```
+    from typing import TYPE_CHECKING
+
+    import unrealsdk
+
+    if TYPE_CHECKING:
+        from enum import auto
+
+        from unrealsdk.unreal._uenum import UnrealEnum  # pyright: ignore[reportMissingModuleSource]
+
+        class MyEnum(UnrealEnum):
+            FieldA = auto()
+            FieldB = auto()
+
+    else:
+        MyEnum = unrealsdk.find_enum("MyEnum")
+    ```
+    """
+
 class UEnum(UField):
-    def _as_py(self) -> type[_UnrealEnum]:
+    def _as_py(self) -> type[_GenericUnrealEnum]:
         """
         Generates a compatible IntFlag enum.
 


### PR DESCRIPTION
`_unreal` no longer shows up as a literal
you can create your own enum subclasses to further type hint known values