### PR TITLE
improve explict python version downloads

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,8 +16,6 @@ env:
   # xwin settings
   XWIN_VERSION: xwin-0.5.0-x86_64-unknown-linux-musl
   XWIN_DOWNLOAD: https://github.com/Jake-Shadle/xwin/releases/download/0.5.0/xwin-0.5.0-x86_64-unknown-linux-musl.tar.gz
-  # Python settings
-  PYTHON_VERSION: "3.12.3"
 
 jobs:
   cache-clang:
@@ -89,12 +87,7 @@ jobs:
       run: |
         pip install requests
 
-        python common_cmake/explicit_python/download.py                           `
-          ${{ env.PYTHON_VERSION }}                                               `
-          ${{ fromJSON('["win32", "amd64"]')[contains(matrix.preset, 'x64')] }}   `
-          --no-debug
-
-        cmake . --preset ${{ matrix.preset }}
+        cmake . --preset ${{ matrix.preset }} -G Ninja
 
     - name: Build
       working-directory: ${{ env.GITHUB_WORKSPACE }}
@@ -198,16 +191,11 @@ jobs:
       run: |
         pip install requests
 
-        python common_cmake/explicit_python/download.py                           \
-          ${{ env.PYTHON_VERSION }}                                               \
-          ${{ fromJSON('["win32", "amd64"]')[contains(matrix.preset, 'x64')] }}   \
-          --no-debug
-
         cmake .                           \
         --preset ${{ matrix.preset }}     \
         -G Ninja                          \
         -DXWIN_DIR=$(readlink -f ~)/xwin
-      # The extra xwin dir arg won't do anything if we're not cross compiling
+      # The extra xwin dir arg will be ignored if we don't need it
 
     - name: Build
       working-directory: ${{ env.GITHUB_WORKSPACE }}
@@ -254,12 +242,10 @@ jobs:
       run: |
         pip install pyyaml requests
 
-        python common_cmake/explicit_python/download.py                         `
-          ${{ env.PYTHON_VERSION }}                                             `
-          ${{ fromJSON('["win32", "amd64"]')[contains(matrix.preset, 'x64')] }} `
-          --no-debug
-
-        cmake . --preset ${{ matrix.preset }} -DCMAKE_DISABLE_PRECOMPILE_HEADERS=On
+        cmake .                                   `
+        --preset ${{ matrix.preset }}             `
+        -G Ninja                                  `
+        -DCMAKE_DISABLE_PRECOMPILE_HEADERS=True
 
         (Get-Content "out\build\${{ matrix.preset }}\compile_commands.json")    `
           -replace "@CMakeFiles.+?\.modmap", ""                                 `

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -5,7 +5,10 @@
       "name": "_base",
       "hidden": true,
       "binaryDir": "${sourceDir}/out/build/${presetName}",
-      "installDir": "${sourceDir}/out/install/${presetName}"
+      "installDir": "${sourceDir}/out/install/${presetName}",
+      "cacheVariables": {
+        "EXPLICIT_PYTHON_VERSION": "3.12.3"
+      }
     },
     {
       "name": "_clang_x86",
@@ -111,6 +114,7 @@
         "strategy": "external"
       },
       "cacheVariables": {
+        "EXPLICIT_PYTHON_ARCH": "win32",
         "UNREALSDK_ARCH": "x86"
       }
     },
@@ -122,6 +126,7 @@
         "strategy": "external"
       },
       "cacheVariables": {
+        "EXPLICIT_PYTHON_ARCH": "amd64",
         "UNREALSDK_ARCH": "x64"
       }
     },

--- a/Readme.md
+++ b/Readme.md
@@ -116,17 +116,22 @@ To build:
    git clone --recursive https://github.com/bl-sdk/pyunrealsdk.git
    ```
 
-2. Setup the python dev files. The simplest way is as follows:
+2. Make sure you have Python with requests on your PATH. This doesn't need to be the same version
+   as what the SDK uses, it's just used by the script which downloads the correct one.
    ```sh
-   apt install msitools # Or equivalent for other package managers, not required on Windows
-
-   cd common_cmake/explicit_python
    pip install requests
-   python download.py 3.11.4 amd64
+   python -c 'import requests'
    ```
 
-   See the [readme](https://github.com/bl-sdk/common_cmake/blob/master/explicit_python/Readme.md)
-   for more advanced details.
+   If not running on Windows, make sure `msiextract` is also on your PATH. This is typically part
+   of an `msitools` package.
+   ```sh
+   apt install msitools # Or equivalent
+   msiextract --version 
+   ```
+
+   See the explicit python [readme](https://github.com/bl-sdk/common_cmake/blob/master/explicit_python/Readme.md)
+   for a few extra details.
 
 3. (OPTIONAL) Copy `postbuild.template`, and edit it to copy files to your game install directories.
 
@@ -140,8 +145,8 @@ To build:
    want these:
    ```
    python3.dll
-   python311.dll
-   python311.zip
+   python3<version>.dll
+   python3<version>.zip
    ```
 
    A CMake install will copy these files, as well as several other useful libraries, to the install


### PR DESCRIPTION
should now be done during configuration, not an extra step