### PR TITLE
properly update cruft to py312

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "git@github.com:bl-sdk/common_dotfiles.git",
-  "commit": "57d16dc4c4604beb228e8c04c31fb010954eb466",
+  "commit": "138df08443b451852ec12a7de0a38882a0298408",
   "checkout": null,
   "context": {
     "cookiecutter": {

--- a/linters.txt
+++ b/linters.txt
@@ -1,3 +1,0 @@
-black
-ruff
-pyright

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,8 @@ include = ["stubs"]
 [tool.ruff]
 target-version = "py312"
 line-length = 100
+
+[tool.ruff.lint]
 select = [
     "F",
     "W",
@@ -30,6 +32,7 @@ select = [
     "FA",
     "ISC",
     "ICN",
+    "LOG",
     "G",
     "PIE",
     "PYI",
@@ -51,7 +54,6 @@ select = [
     "FLY",
     "PERF",
     "FURB",
-    "LOG",
     "RUF",
 ]
 ignore = [
@@ -94,5 +96,5 @@ ignore = [
     "FURB140",
 ]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "*.pyi" = ["D418", "A002", "A003"]


### PR DESCRIPTION
seems I edited the pyproject directly, but the cruft itself still said 3.11 this also updates to the new the ruff options